### PR TITLE
Fix messages not-friends bug and enable WebSocket proxying

### DIFF
--- a/apps/web/src/components/home/MessagesTab.jsx
+++ b/apps/web/src/components/home/MessagesTab.jsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, useTransition } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { MessageCircle, ArrowLeft, Send, Loader2, PenSquare, Search } from 'lucide-react';
 import { Button } from '../ui/UI';
@@ -505,6 +505,7 @@ function ThreadView({ otherPlayerId, otherPlayerName, otherPlayerAvatar, isFrien
 export default function MessagesTab() {
   const searchParams = useSearchParams();
   const router = useRouter();
+  const [, startTransition] = useTransition();
 
   // thread param from URL (e.g. ?tab=messages&thread=123)
   const threadPlayerId = searchParams?.get('thread');
@@ -545,9 +546,10 @@ export default function MessagesTab() {
                 playerId: p.id,
                 name: p.full_name,
                 avatar: p.avatar || null,
-                isFriend: statusData.statuses?.[p.id] === 'friends',
+                isFriend: statusData.statuses?.[String(p.id)] === 'friend',
               });
-            } catch {
+            } catch (innerErr) {
+              console.error('Error fetching thread player info:', innerErr);
               setThreadInfo({
                 playerId: Number(threadPlayerId),
                 name: 'Unknown Player',
@@ -565,20 +567,19 @@ export default function MessagesTab() {
 
   const openThread = useCallback((playerId, name, avatar, isFriend) => {
     setThreadInfo({ playerId, name, avatar, isFriend });
-    // Update URL for back button without triggering Next.js navigation/Suspense re-mount
     const params = new URLSearchParams(window.location.search);
     params.set('tab', 'messages');
     params.set('thread', String(playerId));
-    window.history.pushState(null, '', `/home?${params.toString()}`);
-  }, []);
+    startTransition(() => router.push(`/home?${params.toString()}`));
+  }, [router, startTransition]);
 
   const closeThread = useCallback(() => {
     setThreadInfo(null);
     const params = new URLSearchParams(window.location.search);
     params.set('tab', 'messages');
     params.delete('thread');
-    window.history.pushState(null, '', `/home?${params.toString()}`);
-  }, []);
+    startTransition(() => router.push(`/home?${params.toString()}`));
+  }, [router, startTransition]);
 
   if (threadInfo) {
     return (

--- a/apps/web/src/components/player/PlayerPopover.jsx
+++ b/apps/web/src/components/player/PlayerPopover.jsx
@@ -46,7 +46,7 @@ export default function PlayerPopover({
       try {
         const result = await batchFriendStatus([playerId]);
         if (cancelled) return;
-        const status = result.statuses?.[playerId] || 'none';
+        const status = result.statuses?.[String(playerId)] || 'none';
         setFriendStatus(status);
         onCacheUpdate?.(playerId, status);
 

--- a/deployment/dev/nginx/dev.beachleaguevb.com.conf
+++ b/deployment/dev/nginx/dev.beachleaguevb.com.conf
@@ -5,6 +5,12 @@
 # Rate limit zone — 30 requests/sec per IP, burst up to 60
 limit_req_zone $binary_remote_addr zone=global_dev:10m rate=30r/s;
 
+# Conditional upgrade header: "upgrade" for WebSocket, "close" for regular HTTP
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
 # HTTP server — certbot will auto-add redirect to HTTPS
 server {
     listen 80;
@@ -31,6 +37,23 @@ server {
         return 444;
     }
 
+    # WebSocket endpoint — long-lived connections for real-time notifications
+    location /api/ws/ {
+        proxy_pass http://localhost:8000;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 3600s;
+        proxy_read_timeout 3600s;
+    }
+
     # Proxy API requests to backend (FastAPI on port 8000)
     location /api/ {
         client_max_body_size 10m;
@@ -44,13 +67,9 @@ server {
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Port $server_port;
 
-        # WebSocket support (for /api/ws/notifications)
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-
         proxy_connect_timeout 60s;
         proxy_send_timeout 120s;
-        proxy_read_timeout 3600s;
+        proxy_read_timeout 120s;
     }
 
     # Proxy all other requests to frontend (Next.js on port 3000)
@@ -65,9 +84,9 @@ server {
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Port $server_port;
 
-        # WebSocket support
+        # WebSocket support (Next.js HMR)
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
+        proxy_set_header Connection $connection_upgrade;
 
         proxy_connect_timeout 60s;
         proxy_send_timeout 60s;

--- a/deployment/nginx/beachleaguevb.com-https.conf.template
+++ b/deployment/nginx/beachleaguevb.com-https.conf.template
@@ -1,6 +1,12 @@
 # Rate limit zone — 30 requests/sec per IP, burst up to 60
 limit_req_zone $binary_remote_addr zone=global_https:10m rate=30r/s;
 
+# Conditional upgrade header: "upgrade" for WebSocket, "close" for regular HTTP
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
 # HTTPS server block template
 # This is appended to the nginx config after SSL certificates are obtained
 server {
@@ -28,6 +34,23 @@ server {
         return 444;
     }
 
+    # WebSocket endpoint — long-lived connections for real-time notifications
+    location /api/ws/ {
+        proxy_pass http://localhost:8000;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 3600s;
+        proxy_read_timeout 3600s;
+    }
+
     # Proxy API requests to backend (FastAPI on port 8000)
     location /api/ {
         client_max_body_size 10m;
@@ -42,14 +65,10 @@ server {
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Port $server_port;
 
-        # WebSocket support (for /api/ws/notifications)
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-
-        # Timeouts (longer for photo uploads and WebSocket connections)
+        # Timeouts (longer for photo uploads on mobile)
         proxy_connect_timeout 60s;
         proxy_send_timeout 120s;
-        proxy_read_timeout 3600s;
+        proxy_read_timeout 120s;
     }
 
     # Proxy all other requests to frontend (Next.js on port 3000)
@@ -67,7 +86,7 @@ server {
         
         # WebSocket support (for Next.js HMR in dev, if needed)
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
+        proxy_set_header Connection $connection_upgrade;
         
         # Timeouts
         proxy_connect_timeout 60s;

--- a/deployment/nginx/beachleaguevb.com.conf
+++ b/deployment/nginx/beachleaguevb.com.conf
@@ -8,6 +8,12 @@
 # Rate limit zone — 30 requests/sec per IP, burst up to 60
 limit_req_zone $binary_remote_addr zone=global:10m rate=30r/s;
 
+# Conditional upgrade header: "upgrade" for WebSocket, "close" for regular HTTP
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
 # HTTP server - initially proxies to app, will redirect to HTTPS after SSL setup
 server {
     listen 80;
@@ -28,6 +34,23 @@ server {
         return 444;
     }
 
+    # WebSocket endpoint — long-lived connections for real-time notifications
+    location /api/ws/ {
+        proxy_pass http://localhost:8000;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 3600s;
+        proxy_read_timeout 3600s;
+    }
+
     # Proxy API requests to backend (FastAPI on port 8000)
     location /api/ {
         client_max_body_size 10m;
@@ -42,14 +65,10 @@ server {
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Port $server_port;
 
-        # WebSocket support (for /api/ws/notifications)
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-
-        # Timeouts (longer for photo uploads and WebSocket connections)
+        # Timeouts (longer for photo uploads on mobile)
         proxy_connect_timeout 60s;
         proxy_send_timeout 120s;
-        proxy_read_timeout 3600s;
+        proxy_read_timeout 120s;
     }
 
     # Proxy all other requests to frontend (Next.js on port 3000)
@@ -67,7 +86,7 @@ server {
         
         # WebSocket support (for Next.js HMR in dev, if needed)
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
+        proxy_set_header Connection $connection_upgrade;
         
         # Timeouts
         proxy_connect_timeout 60s;


### PR DESCRIPTION
## Summary
- Fix messages tab "not friends" bug preventing DM conversations from loading
- Enable WebSocket proxying in nginx configs (dev + prod) for real-time notifications

## Test plan
- [ ] Verify messages tab loads conversations between friends
- [ ] Verify WebSocket notifications connect through nginx proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)