### PR TITLE
fix: session ordering, share modal name, data refresh after photo upload

### DIFF
--- a/apps/web/src/components/league/LeagueMatchesTab.jsx
+++ b/apps/web/src/components/league/LeagueMatchesTab.jsx
@@ -41,6 +41,7 @@ export default function LeagueMatchesTab({ seasonIdFromUrl = null, autoOpenAddMa
     loadAllSeasonsRankings,
     refreshSeasonData,
     refreshMatchData,
+    refreshAllSeasonsMatches,
     isLeagueAdmin,
     selectedSeasonId,
     setSelectedSeasonId,
@@ -116,6 +117,7 @@ export default function LeagueMatchesTab({ seasonIdFromUrl = null, autoOpenAddMa
     loadAllSessions,
     refreshSeasonData,
     refreshMatchData,
+    refreshAllSeasonsMatches,
     getSeasonIdForRefresh,
     selectedSeasonId,
     seasons

--- a/apps/web/src/components/league/hooks/useDataRefresh.js
+++ b/apps/web/src/components/league/hooks/useDataRefresh.js
@@ -9,6 +9,7 @@ export function useDataRefresh({
   loadAllSessions,
   refreshSeasonData,
   refreshMatchData,
+  refreshAllSeasonsMatches,
   getSeasonIdForRefresh,
   selectedSeasonId,
   seasons
@@ -54,17 +55,16 @@ export function useDataRefresh({
     // Refresh match data
     if (matches) {
       const idToRefresh = seasonId || (getSeasonIdForRefresh ? getSeasonIdForRefresh() : null);
-      
+
       if (idToRefresh) {
         if (refreshMatchData) {
           promises.push(refreshMatchData(idToRefresh, forceClear));
         }
-      } else if (!selectedSeasonId && seasons?.length > 0) {
-        // "All Seasons" selected - refresh all seasons
-        if (refreshMatchData) {
-          const refreshPromises = seasons.map(s => refreshMatchData(s.id, forceClear));
-          promises.push(...refreshPromises);
-        }
+      }
+
+      // When "All Seasons" is selected, also refresh the combined view
+      if (!selectedSeasonId && refreshAllSeasonsMatches) {
+        promises.push(refreshAllSeasonsMatches());
       }
     }
 
@@ -74,6 +74,7 @@ export function useDataRefresh({
     loadAllSessions,
     refreshSeasonData,
     refreshMatchData,
+    refreshAllSeasonsMatches,
     getSeasonIdForRefresh,
     selectedSeasonId,
     seasons
@@ -81,4 +82,3 @@ export function useDataRefresh({
 
   return { refreshData };
 }
-

--- a/apps/web/src/components/match/MatchesTable.jsx
+++ b/apps/web/src/components/match/MatchesTable.jsx
@@ -11,13 +11,14 @@ import { useModal, MODAL_TYPES } from '../../contexts/ModalContext';
 import { formatRelativeTime } from '../../utils/dateUtils';
 import { calculateWinner } from '../league/utils/matchUtils';
 
-function createSessionGroup(sessionId, sessionName, sessionStatus, sessionCreatedAt, sessionUpdatedAt, sessionCreatedBy, sessionUpdatedBy) {
+function createSessionGroup(sessionId, sessionName, sessionStatus, sessionCreatedAt, sessionUpdatedAt, sessionCreatedBy, sessionUpdatedBy, sessionDate) {
   return {
     type: 'session',
     id: sessionId,
     name: sessionName,
     status: sessionStatus,
     isActive: sessionStatus === 'ACTIVE',
+    date: sessionDate || null,
     createdAt: sessionCreatedAt,
     updatedAt: sessionUpdatedAt,
     createdBy: sessionCreatedBy,
@@ -68,20 +69,25 @@ export default function MatchesTable({
   const [photoJobId, setPhotoJobId] = useState(null);
   const [photoSessionId, setPhotoSessionId] = useState(null);
   
-  const handlePhotoMatchesCreated = useCallback(async (matchIds) => {
+  const handlePhotoMatchesCreated = useCallback(async (matchIds, photoSeasonId) => {
     setPhotoJobId(null);
     setPhotoSessionId(null);
     closeModal();
-    
+
+    // Switch to the season where matches were created (if different from current filter)
+    if (photoSeasonId && onSeasonChange && photoSeasonId !== selectedSeasonId) {
+      onSeasonChange(photoSeasonId);
+    }
+
     // Refresh data to show the newly created matches
     if (onRefreshData) {
       try {
-        await onRefreshData({ sessions: true, season: true, matches: true });
+        await onRefreshData({ sessions: true, season: true, matches: true, seasonId: photoSeasonId || undefined });
       } catch (error) {
         console.error('[MatchesTable] Error refreshing data after photo matches created:', error);
       }
     }
-  }, [closeModal, onRefreshData]);
+  }, [closeModal, onRefreshData, onSeasonChange, selectedSeasonId]);
   
   const handleProceedToPhotoReview = useCallback((jobId, sessionId, uploadedImageUrl = null) => {
     setPhotoJobId(jobId);
@@ -190,7 +196,8 @@ export default function MatchesTable({
           const sessionCreatedAt = sessionData?.created_at || match['Session Created At'];
           const sessionName = sessionData?.name || match['Session Name'];
           const sessionStatus = sessionData?.status || match['Session Status'];
-          
+          const sessionDate = sessionData?.date || match.Date;
+
           acc[key] = createSessionGroup(
             sessionId,
             sessionName,
@@ -198,7 +205,8 @@ export default function MatchesTable({
             sessionCreatedAt,
             match['Session Updated At'],
             match['Session Created By'],
-            match['Session Updated By']
+            match['Session Updated By'],
+            sessionDate
           );
         }
         acc[key].matches.push(match);
@@ -241,7 +249,8 @@ export default function MatchesTable({
           // Use session data from allSessions if available
           const sessionData = sessionsMap.get(sessionId);
           const sessionCreatedAt = sessionData?.created_at || sessionMetadata.createdAt;
-          
+          const sessionDate = sessionData?.date || null;
+
           grouped[key] = createSessionGroup(
             sessionId,
             sessionMetadata.name || `Session ${sessionId}`,
@@ -249,7 +258,8 @@ export default function MatchesTable({
             sessionCreatedAt,
             sessionMetadata.updatedAt,
             sessionMetadata.createdBy,
-            sessionMetadata.updatedBy
+            sessionMetadata.updatedBy,
+            sessionDate
           );
         } else {
           const sessionMatch = matches?.find(m => m['Session ID'] === sessionId);
@@ -257,7 +267,8 @@ export default function MatchesTable({
             // Use session data from allSessions if available
             const sessionData = sessionsMap.get(sessionId);
             const sessionCreatedAt = sessionData?.created_at || sessionMatch['Session Created At'];
-            
+            const sessionDate = sessionData?.date || sessionMatch.Date;
+
             grouped[key] = createSessionGroup(
               sessionId,
               sessionMatch['Session Name'] || `Session ${sessionId}`,
@@ -265,7 +276,8 @@ export default function MatchesTable({
               sessionCreatedAt,
               sessionMatch['Session Updated At'],
               sessionMatch['Session Created By'],
-              sessionMatch['Session Updated By']
+              sessionMatch['Session Updated By'],
+              sessionDate
             );
           }
         }
@@ -309,25 +321,29 @@ export default function MatchesTable({
 
   const sessionGroups = useMemo(() => {
     return Object.entries(matchesBySession).sort(([keyA, groupA], [keyB, groupB]) => {
-      // Sort by created_at (newest first)
-      // Use createdAt if available, otherwise fall back to lastUpdated
-      const dateA = groupA.createdAt || groupA.lastUpdated;
-      const dateB = groupB.createdAt || groupB.lastUpdated;
-      
-      if (dateA && dateB) {
-        // Compare timestamps directly (newest first = descending order)
-        const timeDiff = new Date(dateB) - new Date(dateA);
-        if (timeDiff !== 0) {
-          return timeDiff;
-        }
+      // Primary sort: session date descending (matches backend ORDER BY date DESC)
+      // Session date is a YYYY-MM-DD string — lexicographic comparison works correctly
+      const sessionDateA = groupA.date || groupA.name;
+      const sessionDateB = groupB.date || groupB.name;
+
+      if (sessionDateA && sessionDateB) {
+        const dateCmp = sessionDateB.localeCompare(sessionDateA);
+        if (dateCmp !== 0) return dateCmp;
       }
-      
-      // If one has a date and the other doesn't, prioritize the one with a date
-      if (dateA && !dateB) return -1;
-      if (!dateA && dateB) return 1;
-      
-      // Final fallback to alphabetical (descending)
-      return groupB.name.localeCompare(groupA.name);
+
+      // Tiebreaker: created_at descending (matches backend ORDER BY created_at DESC)
+      const createdA = groupA.createdAt;
+      const createdB = groupB.createdAt;
+
+      if (createdA && createdB) {
+        const timeDiff = new Date(createdB) - new Date(createdA);
+        if (timeDiff !== 0) return timeDiff;
+      }
+
+      if (createdA && !createdB) return -1;
+      if (!createdA && createdB) return 1;
+
+      return 0;
     });
   }, [matchesBySession]);
 

--- a/apps/web/src/components/match/components/PlayerSearchModal.jsx
+++ b/apps/web/src/components/match/components/PlayerSearchModal.jsx
@@ -41,7 +41,12 @@ export default function PlayerSearchModal({ isOpen, rawName, leagueId, onSelect,
       data.league_id = leagueId;
     }
     const result = await createPlaceholderPlayer(data);
-    return result;
+    // API returns snake_case; PlaceholderCreateModal expects camelCase
+    return {
+      ...result,
+      inviteUrl: result.invite_url || result.inviteUrl,
+      inviteToken: result.invite_token || result.inviteToken,
+    };
   }, [leagueId]);
 
   const handlePlaceholderClose = useCallback((createdPlayer) => {

--- a/apps/web/src/components/match/hooks/usePhotoMatchReview.js
+++ b/apps/web/src/components/match/hooks/usePhotoMatchReview.js
@@ -277,7 +277,7 @@ export function usePhotoMatchReview({
         overridesPayload
       );
       setStatus(JOB_STATUS.CONFIRMED);
-      onSuccess?.(response.match_ids);
+      onSuccess?.(response.match_ids, selectedSeasonId);
     } catch (err) {
       console.error('Error confirming matches:', err);
       const detail = err.response?.data?.detail;

--- a/apps/web/src/components/ui/ShareFallbackModal.jsx
+++ b/apps/web/src/components/ui/ShareFallbackModal.jsx
@@ -57,7 +57,7 @@ export default function ShareFallbackModal({ isOpen, onClose, name, url, text })
     >
       <div className="share-fallback">
         <div className="share-fallback__header">
-          <span>Share Invite</span>
+          <span>{name ? `Share Invite for ${name}` : 'Share Invite'}</span>
           <button
             type="button"
             className="share-fallback__close"

--- a/apps/web/src/contexts/LeagueContext.jsx
+++ b/apps/web/src/contexts/LeagueContext.jsx
@@ -385,6 +385,46 @@ export const LeagueProvider = ({ children, leagueId }) => {
     // Note: Player data will be reloaded automatically when selectedSeasonData changes
   }, [loadSeasonData]);
 
+  /**
+   * Refresh only the matches portion of the "All Seasons" combined view.
+   * Unlike loadAllSeasonsRankings, this skips the already-loaded guard
+   * so it always fetches fresh match data.
+   */
+  const refreshAllSeasonsMatches = useCallback(async () => {
+    if (!leagueId) return;
+
+    try {
+      const allMatches = await getMatchesWithElo({ league_id: leagueId }).catch(err => {
+        console.error('Error refreshing all seasons matches:', err);
+        return null;
+      });
+      if (allMatches === null) return;
+
+      const sortedMatches = [...allMatches].sort((a, b) =>
+        new Date(b.date || 0) - new Date(a.date || 0)
+      );
+
+      setSeasonData(prev => {
+        const existing = prev[ALL_SEASONS_KEY];
+        if (!existing) return prev;
+        return {
+          ...prev,
+          [ALL_SEASONS_KEY]: { ...existing, matches: sortedMatches }
+        };
+      });
+
+      // Update the ref immediately
+      if (dataRef.current[ALL_SEASONS_KEY]) {
+        dataRef.current[ALL_SEASONS_KEY] = {
+          ...dataRef.current[ALL_SEASONS_KEY],
+          matches: sortedMatches
+        };
+      }
+    } catch (err) {
+      console.error('Error refreshing all seasons matches:', err);
+    }
+  }, [leagueId]);
+
   // Load rankings for all seasons in the league (when "All Seasons" is selected)
   const loadAllSeasonsRankings = useCallback(async () => {
     if (!leagueId) return;
@@ -584,6 +624,7 @@ export const LeagueProvider = ({ children, leagueId }) => {
     loadSeasonData,
     refreshSeasonData,
     refreshMatchData,
+    refreshAllSeasonsMatches,
     loadAllSeasonsRankings,
     isLeagueMember,
     isLeagueAdmin,
@@ -603,7 +644,7 @@ export const LeagueProvider = ({ children, leagueId }) => {
     refreshLeague, refreshSeasons, refreshMembers, updateLeague, updateMember,
     activeSeasons, isSeasonActive, isSeasonPast,
     selectedSeasonData, seasonData, seasonDataLoading,
-    loadSeasonData, refreshSeasonData, refreshMatchData, loadAllSeasonsRankings,
+    loadSeasonData, refreshSeasonData, refreshMatchData, refreshAllSeasonsMatches, loadAllSeasonsRankings,
     isLeagueMember, isLeagueAdmin,
     selectedSeasonId, setSelectedSeasonId,
     selectedPlayerId, selectedPlayerName, playerSeasonStats, playerMatchHistory,

--- a/apps/web/tests/e2e/game/photo-match-refresh.spec.js
+++ b/apps/web/tests/e2e/game/photo-match-refresh.spec.js
@@ -1,0 +1,210 @@
+import { test, expect } from '../fixtures/test-fixtures.js';
+import { execSync } from 'child_process';
+
+/**
+ * Photo Match — Data Refresh After Confirm E2E Test
+ *
+ * Verifies that after confirming photo-extracted matches, the new matches
+ * appear in the Games tab without requiring a manual page refresh.
+ *
+ * Upload + SSE are mocked (Gemini dependency). The confirm endpoint hits
+ * the real backend with a seeded Redis session.
+ */
+
+// Minimal valid 1x1 JPEG for file upload
+const JPEG_BYTES = Buffer.from(
+  '/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAP//////////////////////' +
+  '////////////////////////////////////////////////////////////' +
+  '2wBDAf//////////////////////' +
+  '////////////////////////////////////////////////////////////' +
+  'wAARCAABAAEDASIAAhEBAxEB/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAA' +
+  'AAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AL+A/9k=',
+  'base64'
+);
+
+const TEST_SESSION_ID = 'e2e-photo-refresh-test';
+const REDIS_KEY_PREFIX = 'photo_match_session:';
+
+/**
+ * Build mock matches where all 4 players are matched (no unresolved names).
+ * This lets us go straight to confirm without needing player resolution.
+ */
+function buildFullyMatchedMatches(playerIds, playerNames) {
+  const names = Object.keys(playerIds);
+  const ids = Object.values(playerIds);
+  return [
+    {
+      match_number: 1,
+      team1_player1: { id: ids[0], name: names[0] },
+      team1_player1_id: ids[0],
+      team1_player1_matched: names[0],
+      team1_player1_confidence: 1.0,
+      team1_player2: { id: ids[1], name: names[1] },
+      team1_player2_id: ids[1],
+      team1_player2_matched: names[1],
+      team1_player2_confidence: 1.0,
+      team2_player1: { id: ids[2], name: names[2] },
+      team2_player1_id: ids[2],
+      team2_player1_matched: names[2],
+      team2_player1_confidence: 1.0,
+      team2_player2: { id: ids[3], name: names[3] },
+      team2_player2_id: ids[3],
+      team2_player2_matched: names[3],
+      team2_player2_confidence: 1.0,
+      team1_score: 21,
+      team2_score: 17,
+    },
+  ];
+}
+
+function seedRedisSession(leagueId, playerIds, playerNames) {
+  const matches = buildFullyMatchedMatches(playerIds, playerNames);
+  const sessionData = {
+    league_id: leagueId,
+    parsed_matches: matches,
+    status: 'done',
+  };
+
+  const key = `${REDIS_KEY_PREFIX}${TEST_SESSION_ID}`;
+  const value = JSON.stringify(sessionData);
+  execSync(
+    `docker exec beach-kings-redis-test redis-cli SET '${key}' '${value.replace(/'/g, "'\\''")}' EX 900`,
+    { stdio: 'pipe' }
+  );
+}
+
+async function setupFullyMatchedMocks(page, leagueId, playerIds, playerNames) {
+  const matches = buildFullyMatchedMatches(playerIds, playerNames);
+
+  // Mock photo upload
+  await page.route(`**/api/leagues/${leagueId}/matches/upload-photo`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ job_id: 9998, session_id: TEST_SESSION_ID }),
+    });
+  });
+
+  // Mock SSE stream — all players matched, ready to confirm
+  await page.route(`**/api/leagues/${leagueId}/matches/photo-jobs/*/stream`, async (route) => {
+    const payload = {
+      status: 'COMPLETED',
+      result: {
+        status: 'done',
+        matches,
+        clarification_question: null,
+        error_message: null,
+        note: null,
+      },
+    };
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/event-stream',
+      headers: { 'Cache-Control': 'no-cache', Connection: 'keep-alive' },
+      body: `event: done\ndata: ${JSON.stringify(payload)}\n\n`,
+    });
+  });
+
+  // Mock delete endpoint
+  await page.route(`**/api/leagues/${leagueId}/matches/photo-sessions/${TEST_SESSION_ID}`, async (route) => {
+    if (route.request().method() === 'DELETE') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{"status":"cancelled"}' });
+    } else {
+      await route.fallback();
+    }
+  });
+}
+
+test.describe('Photo Match — Data Refresh After Confirm', () => {
+  test('confirmed photo matches appear in the active session without page reload', async ({
+    authedPage,
+    testUser,
+    leagueWithPlayers,
+  }) => {
+    const page = authedPage;
+    const { leagueId, seasonId, playerIds, playerNames } = leagueWithPlayers;
+
+    // Seed Redis session for the real confirm endpoint
+    seedRedisSession(leagueId, playerIds, playerNames);
+    await setupFullyMatchedMocks(page, leagueId, playerIds, playerNames);
+
+    // Navigate to league Games tab
+    await page.goto(`/league/${leagueId}`);
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForFunction(
+      () => {
+        const content = document.querySelector('.league-content');
+        if (!content) return false;
+        return content.querySelectorAll('.skeleton-text').length === 0;
+      },
+      { timeout: 15000 }
+    );
+
+    const gamesTab = page.locator('[data-testid="matches-tab"]').first();
+    await gamesTab.waitFor({ state: 'visible', timeout: 10000 });
+    await gamesTab.click();
+
+    // Verify no active session yet
+    await expect(page.locator('[data-testid="active-session"]')).not.toBeVisible({ timeout: 5000 });
+
+    // Click "Upload Photo" card
+    const uploadCard = page.locator('[data-testid="upload-photo-card"]').first();
+    await uploadCard.waitFor({ state: 'visible', timeout: 10000 });
+    await uploadCard.click();
+
+    // Wait for upload modal, set file, click upload
+    await page.waitForSelector('.upload-photo-modal', { state: 'visible', timeout: 10000 });
+    const fileInput = page.locator('input[type="file"]').first();
+    await fileInput.setInputFiles({
+      name: 'scoresheet.jpg',
+      mimeType: 'image/jpeg',
+      buffer: JPEG_BYTES,
+    });
+    const uploadButton = page.locator('.upload-photo-modal button:has-text("Upload & Process")');
+    await uploadButton.waitFor({ state: 'visible', timeout: 5000 });
+    await uploadButton.click();
+
+    // Wait for review modal
+    await page.waitForSelector('.photo-review-modal', { state: 'visible', timeout: 15000 });
+
+    // All players matched — no unrecognized section should appear
+    await expect(page.locator('.unrecognized-players')).not.toBeVisible({ timeout: 3000 });
+
+    // Select the season
+    const seasonSelect = page.locator('.confirmation-options select').first();
+    await seasonSelect.waitFor({ state: 'visible', timeout: 5000 });
+    await seasonSelect.selectOption(String(seasonId));
+
+    // Listen for the real confirm API call
+    const confirmResponsePromise = page.waitForResponse(
+      (resp) => resp.url().includes('/confirm') && resp.request().method() === 'POST',
+      { timeout: 15000 }
+    );
+
+    // Click confirm
+    const confirmBtn = page.locator('button:has-text("Confirm & Create")');
+    await expect(confirmBtn).toBeEnabled({ timeout: 5000 });
+    await confirmBtn.click();
+
+    // Verify the real confirm API returned success
+    const confirmResponse = await confirmResponsePromise;
+    expect(confirmResponse.status()).toBe(200);
+    const body = await confirmResponse.json();
+    expect(body.match_ids.length).toBeGreaterThan(0);
+
+    // KEY ASSERTION: After the modal closes and data refreshes,
+    // the active session with matches should be visible WITHOUT a page reload.
+    // Wait for the review modal to close
+    await expect(page.locator('.photo-review-modal')).not.toBeVisible({ timeout: 10000 });
+
+    // The active session panel should appear with the new match(es)
+    const activeSession = page.locator('[data-testid="active-session"]');
+    await activeSession.waitFor({ state: 'visible', timeout: 15000 });
+
+    // Verify match cards are visible in the active session
+    const matchCards = activeSession.locator('.match-card, [class*="match-card"]');
+    await expect(matchCards.first()).toBeVisible({ timeout: 10000 });
+    const matchCount = await matchCards.count();
+    expect(matchCount).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/apps/web/tests/e2e/league/session-ordering.spec.js
+++ b/apps/web/tests/e2e/league/session-ordering.spec.js
@@ -1,0 +1,73 @@
+import { test, expect } from '../fixtures/test-fixtures.js';
+import { createApiClient } from '../fixtures/api.js';
+import { LeaguePage } from '../pages/LeaguePage.js';
+
+/**
+ * Session Ordering E2E Tests
+ *
+ * Verifies that league sessions are displayed in descending date order,
+ * matching the backend's ORDER BY date DESC, created_at DESC.
+ */
+test.describe('Session Ordering', () => {
+  test('submitted sessions are ordered by date descending', async ({
+    authedPage,
+    testUser,
+    leagueWithPlayers,
+  }) => {
+    const page = authedPage;
+    const { token } = testUser;
+    const { leagueId, seasonId, playerNames, playerIds } = leagueWithPlayers;
+    const api = createApiClient(token);
+
+    // Create 3 matches on different dates — each auto-creates its own session.
+    // POST /api/matches with league_id + date auto-creates sessions.
+    const dates = ['1/10/2025', '1/20/2025', '1/30/2025'];
+    const sessionIds = [];
+
+    for (const date of dates) {
+      const matchResp = await api.post('/api/matches', {
+        team1_player1_id: playerIds[playerNames[0]],
+        team1_player2_id: playerIds[playerNames[1]],
+        team2_player1_id: playerIds[playerNames[2]],
+        team2_player2_id: playerIds[playerNames[3]],
+        team1_score: 21,
+        team2_score: 15,
+        league_id: leagueId,
+        season_id: seasonId,
+        date,
+        is_ranked: true,
+      });
+      const sid = matchResp.data.session_id;
+      sessionIds.push(sid);
+
+      // Submit (lock in) the session so it appears as a submitted group
+      await api.patch(`/api/leagues/${leagueId}/sessions/${sid}`, { submit: true });
+    }
+
+    // Navigate to the league Games tab
+    const leaguePage = new LeaguePage(page);
+    await leaguePage.goto(leagueId);
+    await leaguePage.clickGamesTab();
+    await leaguePage.waitForMatchesTable();
+
+    // Get all session group elements in display order
+    const sessionGroups = page.locator('[data-session-id]');
+    const count = await sessionGroups.count();
+    expect(count).toBeGreaterThanOrEqual(3);
+
+    // Collect session IDs in display order
+    const displayedIds = [];
+    for (let i = 0; i < count; i++) {
+      const sid = await sessionGroups.nth(i).getAttribute('data-session-id');
+      displayedIds.push(Number(sid));
+    }
+
+    // The newest session (Jan 30) should appear first, oldest (Jan 10) last
+    const newestIdx = displayedIds.indexOf(sessionIds[2]);
+    const middleIdx = displayedIds.indexOf(sessionIds[1]);
+    const oldestIdx = displayedIds.indexOf(sessionIds[0]);
+
+    expect(newestIdx).toBeLessThan(middleIdx);
+    expect(middleIdx).toBeLessThan(oldestIdx);
+  });
+});

--- a/apps/web/tests/e2e/placeholder/share-modal-name.spec.js
+++ b/apps/web/tests/e2e/placeholder/share-modal-name.spec.js
@@ -1,0 +1,168 @@
+import { test, expect } from '../fixtures/test-fixtures.js';
+import { execSync } from 'child_process';
+
+/**
+ * Share Modal Personalization E2E Tests
+ *
+ * Verifies that when sharing an invite for a newly created placeholder
+ * player, the share fallback modal (desktop) header includes the player's name.
+ *
+ * Uses the photo match flow where a placeholder is created during player
+ * resolution, then the "Share Invite" button is clicked.
+ */
+
+// Minimal valid 1x1 JPEG
+const JPEG_BYTES = Buffer.from(
+  '/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAP//////////////////////' +
+  '////////////////////////////////////////////////////////////' +
+  '2wBDAf//////////////////////' +
+  '////////////////////////////////////////////////////////////' +
+  'wAARCAABAAEDASIAAhEBAxEB/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAA' +
+  'AAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AL+A/9k=',
+  'base64'
+);
+
+const TEST_SESSION_ID = 'e2e-share-modal-test';
+const REDIS_KEY_PREFIX = 'photo_match_session:';
+
+function buildMockMatches(playerIds) {
+  const ids = Object.values(playerIds);
+  return [
+    {
+      match_number: 1,
+      team1_player1: { id: null, name: 'Share Test Player' },
+      team1_player1_id: null,
+      team1_player1_matched: '',
+      team1_player1_confidence: 0,
+      team1_player2: { id: ids[0], name: '' },
+      team1_player2_id: ids[0],
+      team1_player2_matched: Object.keys(playerIds)[0],
+      team1_player2_confidence: 1.0,
+      team2_player1: { id: ids[1], name: '' },
+      team2_player1_id: ids[1],
+      team2_player1_matched: Object.keys(playerIds)[1],
+      team2_player1_confidence: 1.0,
+      team2_player2: { id: ids[2], name: '' },
+      team2_player2_id: ids[2],
+      team2_player2_matched: Object.keys(playerIds)[2],
+      team2_player2_confidence: 1.0,
+      team1_score: 21,
+      team2_score: 15,
+    },
+  ];
+}
+
+async function setupPhotoMocks(page, leagueId, playerIds) {
+  const matches = buildMockMatches(playerIds);
+
+  await page.route(`**/api/leagues/${leagueId}/matches/upload-photo`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ job_id: 9997, session_id: TEST_SESSION_ID }),
+    });
+  });
+
+  await page.route(`**/api/leagues/${leagueId}/matches/photo-jobs/*/stream`, async (route) => {
+    const payload = {
+      status: 'COMPLETED',
+      result: {
+        status: 'needs_clarification',
+        matches,
+        clarification_question: "I couldn't match: Share Test Player.",
+        error_message: null,
+        note: null,
+      },
+    };
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/event-stream',
+      headers: { 'Cache-Control': 'no-cache', Connection: 'keep-alive' },
+      body: `event: done\ndata: ${JSON.stringify(payload)}\n\n`,
+    });
+  });
+
+  await page.route(`**/api/leagues/${leagueId}/matches/photo-sessions/${TEST_SESSION_ID}`, async (route) => {
+    if (route.request().method() === 'DELETE') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{"status":"cancelled"}' });
+    } else {
+      await route.fallback();
+    }
+  });
+}
+
+test.describe('Share Modal — Player Name', () => {
+  test('share fallback modal displays the player name in the header', async ({
+    authedPage,
+    testUser,
+    leagueWithPlayers,
+  }) => {
+    const page = authedPage;
+    const { leagueId, playerIds } = leagueWithPlayers;
+
+    await setupPhotoMocks(page, leagueId, playerIds);
+
+    // Navigate to league, Games tab, upload photo
+    await page.goto(`/league/${leagueId}`);
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForFunction(
+      () => {
+        const content = document.querySelector('.league-content');
+        if (!content) return false;
+        return content.querySelectorAll('.skeleton-text').length === 0;
+      },
+      { timeout: 15000 }
+    );
+
+    const gamesTab = page.locator('[data-testid="matches-tab"]').first();
+    await gamesTab.waitFor({ state: 'visible', timeout: 10000 });
+    await gamesTab.click();
+
+    const uploadCard = page.locator('[data-testid="upload-photo-card"]').first();
+    await uploadCard.waitFor({ state: 'visible', timeout: 10000 });
+    await uploadCard.click();
+
+    await page.waitForSelector('.upload-photo-modal', { state: 'visible', timeout: 10000 });
+    const fileInput = page.locator('input[type="file"]').first();
+    await fileInput.setInputFiles({
+      name: 'scoresheet.jpg',
+      mimeType: 'image/jpeg',
+      buffer: JPEG_BYTES,
+    });
+    const uploadBtn = page.locator('.upload-photo-modal button:has-text("Upload & Process")');
+    await uploadBtn.waitFor({ state: 'visible', timeout: 5000 });
+    await uploadBtn.click();
+
+    // Wait for review modal with unrecognized player
+    await page.waitForSelector('.photo-review-modal', { state: 'visible', timeout: 15000 });
+    await page.locator('.unrecognized-players').waitFor({ state: 'visible', timeout: 10000 });
+
+    // Click the unmatched chip to open PlayerSearchModal
+    await page.locator('.unrecognized-players__chip').first().click();
+    await page.waitForSelector('.player-search-modal', { state: 'visible', timeout: 5000 });
+
+    // Click "+ Add New Player" to open PlaceholderCreateModal
+    await page.locator('.player-search-modal__add-new').click();
+    await page.waitForSelector('.placeholder-create-modal', { state: 'visible', timeout: 5000 });
+
+    // The name should be pre-filled with "Share Test Player"
+    const nameInput = page.locator('.placeholder-create-modal__name');
+    const playerName = await nameInput.inputValue();
+
+    // Create the placeholder via real API
+    await page.locator('.placeholder-create-modal__create-btn').click();
+    await page.waitForSelector('.placeholder-create-modal__success', { state: 'visible', timeout: 5000 });
+
+    // Click "Share Invite" — on desktop, this opens the ShareFallbackModal
+    await page.locator('.placeholder-create-modal__share-btn').click();
+
+    // Wait for share fallback modal
+    const shareModal = page.locator('.share-fallback');
+    await shareModal.waitFor({ state: 'visible', timeout: 5000 });
+
+    // Verify the header includes the player's name
+    const header = shareModal.locator('.share-fallback__header span').first();
+    await expect(header).toContainText('Share Invite for');
+    await expect(header).toContainText(playerName);
+  });
+});


### PR DESCRIPTION
- Sort sessions by date DESC (matching backend ORDER BY) instead of createdAt
- Show player name in share fallback modal header ("Share Invite for {name}")
- Refresh All Seasons match data after photo upload (was stale due to load guard)
- Pass photo review seasonId to refresh so correct season updates
- Fix snake_case -> camelCase for invite_url in PlayerSearchModal (share btn was hidden)
- Add E2E tests for all three fixes