### PR TITLE
fix: replace beachkings.com with beachleaguevb.com

### DIFF
--- a/apps/backend/services/placeholder_service.py
+++ b/apps/backend/services/placeholder_service.py
@@ -40,7 +40,7 @@ from backend.models.schemas import (
 
 logger = logging.getLogger(__name__)
 
-FRONTEND_BASE_URL = os.getenv("FRONTEND_URL", "https://beachkings.com")
+FRONTEND_BASE_URL = os.getenv("FRONTEND_URL", "https://beachleaguevb.com")
 
 # --- Module-level constants ---
 

--- a/docs/requirements/placeholder-players.md
+++ b/docs/requirements/placeholder-players.md
@@ -75,7 +75,7 @@ Users frequently want to log matches immediately after playing, but their oppone
 
 1. After match creation, user copies the invite link (from toast, match detail view, or profile "Pending Invites")
 2. User pastes the link into a text message, WhatsApp, etc. and sends it manually
-3. The link format: `https://beachkings.com/invite/{token}`
+3. The link format: `https://beachleaguevb.com/invite/{token}`
 
 ### Claim Flow (Invited Person's Perspective)
 
@@ -183,7 +183,7 @@ When a placeholder is used in a league match, a `LeagueMember` row is created fo
   "player_id": 456,
   "name": "John Smith",
   "invite_token": "abc123...",
-  "invite_url": "https://beachkings.com/invite/abc123..."
+  "invite_url": "https://beachleaguevb.com/invite/abc123..."
 }
 ```
 


### PR DESCRIPTION
## Summary
- Replaced all 3 references to the old `beachkings.com` domain with `beachleaguevb.com`
- Updated the default `FRONTEND_URL` fallback in `placeholder_service.py`
- Updated invite link examples in `docs/requirements/placeholder-players.md`

Note: internal database config names (`beachkings` as postgres user/db) were intentionally left unchanged as they are infrastructure defaults, not public-facing URLs.

## Test plan
- [ ] Verify invite links generated by the backend use `beachleaguevb.com`
- [ ] Confirm no remaining references to `beachkings.com` via `grep -r "beachkings\.com"`

https://claude.ai/code/session_015DSoih8ZX3ubBPo6Kfkfe4