### PR TITLE
feat: P1.10 change password endpoint

### DIFF
--- a/apps/backend/alembic/versions/040_add_password_changed_at.py
+++ b/apps/backend/alembic/versions/040_add_password_changed_at.py
@@ -1,0 +1,45 @@
+"""Add password_changed_at column to users table.
+
+Non-destructive migration: adds a nullable TIMESTAMPTZ column to record
+when a user last changed their password via the change-password endpoint.
+No data migration required.
+
+Revision ID: 040
+Revises: 039
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "040"
+down_revision = "039"
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(table: str, column: str) -> bool:
+    """Check whether a column exists on a table (idempotent guard)."""
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    columns = [c["name"] for c in insp.get_columns(table)]
+    return column in columns
+
+
+def upgrade() -> None:
+    """Add password_changed_at TIMESTAMPTZ NULL to users."""
+    if not _column_exists("users", "password_changed_at"):
+        op.add_column(
+            "users",
+            sa.Column(
+                "password_changed_at",
+                sa.DateTime(timezone=True),
+                nullable=True,
+            ),
+        )
+
+
+def downgrade() -> None:
+    """Drop password_changed_at from users."""
+    if _column_exists("users", "password_changed_at"):
+        op.drop_column("users", "password_changed_at")

--- a/apps/backend/api/routes/auth.py
+++ b/apps/backend/api/routes/auth.py
@@ -41,6 +41,8 @@ from backend.models.schemas import (
     ResetPasswordVerifyRequest,
     ResetPasswordConfirmRequest,
     GoogleAuthRequest,
+    ChangePasswordRequest,
+    ChangePasswordResponse,
 )
 from backend.utils.datetime_utils import utcnow
 
@@ -558,10 +560,6 @@ async def reset_password_confirm(
             raise HTTPException(
                 status_code=400, detail="Password must be at least 8 characters long"
             )
-        if not any(char.isdigit() for char in payload.new_password):
-            raise HTTPException(
-                status_code=400, detail="Password must include at least one number"
-            )
 
         user_id = await user_service.verify_and_use_password_reset_token(
             session, payload.reset_token
@@ -714,6 +712,75 @@ async def get_current_user_info(current_user: dict = Depends(get_current_user)):
         email=current_user.get("email"),
         is_verified=current_user["is_verified"],
         auth_provider=current_user.get("auth_provider", "phone"),
+        has_password=current_user.get("password_hash") is not None,
         deletion_scheduled_at=current_user.get("deletion_scheduled_at"),
         created_at=current_user["created_at"],
     )
+
+
+@router.post("/api/auth/change-password", response_model=ChangePasswordResponse)
+async def change_password(
+    payload: ChangePasswordRequest,
+    current_user: dict = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db_session),
+):
+    """
+    Change the authenticated user's password.
+
+    Verifies the current password, then replaces it with the new one.
+    All other refresh tokens for the user are revoked on success so that
+    other sessions (different devices) are invalidated — the current session's
+    access token remains valid until it expires naturally.
+
+    Returns the ISO-8601 timestamp at which the password was changed.
+    """
+    try:
+        # OAuth-only users have no password hash — they must use password reset first.
+        if not current_user.get("password_hash"):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Your account uses social sign-in. "
+                    "Set a password via password reset first."
+                ),
+            )
+
+        if len(payload.new_password) < 8:
+            raise HTTPException(
+                status_code=400, detail="Password must be at least 8 characters long"
+            )
+
+        if not auth_service.verify_password(
+            payload.current_password, current_user["password_hash"]
+        ):
+            raise HTTPException(status_code=401, detail="Current password is incorrect")
+
+        new_password_hash = auth_service.hash_password(payload.new_password)
+        success = await user_service.update_user_password(
+            session, current_user["id"], new_password_hash
+        )
+        if not success:
+            raise HTTPException(status_code=500, detail="Failed to update password")
+
+        # Revoke all refresh tokens so other sessions are invalidated.
+        await user_service.delete_user_refresh_tokens(session, current_user["id"])
+
+        # Re-fetch the user to get the freshly-written password_changed_at value.
+        updated_user = await user_service.get_user_by_id(session, current_user["id"])
+        password_changed_at = (
+            updated_user.get("password_changed_at") or utcnow().isoformat()
+            if updated_user
+            else utcnow().isoformat()
+        )
+
+        return ChangePasswordResponse(
+            status="success",
+            password_changed_at=password_changed_at,
+        )
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("Error changing password")
+        raise HTTPException(
+            status_code=500, detail="Error changing password. Please try again."
+        )

--- a/apps/backend/database/models.py
+++ b/apps/backend/database/models.py
@@ -173,6 +173,7 @@ class User(Base):
     failed_verification_attempts = Column(Integer, default=0, nullable=False)
     locked_until = Column(String, nullable=True)  # ISO timestamp
     deletion_scheduled_at = Column(DateTime(timezone=True), nullable=True)
+    password_changed_at = Column(DateTime(timezone=True), nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 

--- a/apps/backend/models/schemas.py
+++ b/apps/backend/models/schemas.py
@@ -358,6 +358,20 @@ class ResetPasswordConfirmRequest(BaseModel):
     new_password: str
 
 
+class ChangePasswordRequest(BaseModel):
+    """Request to change the authenticated user's password."""
+
+    current_password: str
+    new_password: str
+
+
+class ChangePasswordResponse(BaseModel):
+    """Response after a successful password change."""
+
+    status: str
+    password_changed_at: str
+
+
 class UserResponse(BaseModel):
     """User information response."""
 
@@ -366,6 +380,7 @@ class UserResponse(BaseModel):
     email: Optional[str] = None
     is_verified: bool
     auth_provider: str = "phone"
+    has_password: bool = True
     deletion_scheduled_at: Optional[str] = None
     created_at: str
 

--- a/apps/backend/services/user_service.py
+++ b/apps/backend/services/user_service.py
@@ -95,7 +95,7 @@ async def create_user(
 
 async def update_user_password(session: AsyncSession, user_id: int, password_hash: str) -> bool:
     """
-    Update a user's password.
+    Update a user's password and record the change timestamp.
 
     Args:
         session: Database session
@@ -108,7 +108,11 @@ async def update_user_password(session: AsyncSession, user_id: int, password_has
     result = await session.execute(
         update(User)
         .where(User.id == user_id)
-        .values(password_hash=password_hash, updated_at=func.now())
+        .values(
+            password_hash=password_hash,
+            password_changed_at=func.now(),
+            updated_at=func.now(),
+        )
     )
     await session.commit()
     return result.rowcount > 0
@@ -300,6 +304,9 @@ def _user_to_dict(user: User) -> Dict:
         "locked_until": user.locked_until,
         "deletion_scheduled_at": (
             user.deletion_scheduled_at.isoformat() if user.deletion_scheduled_at else None
+        ),
+        "password_changed_at": (
+            user.password_changed_at.isoformat() if user.password_changed_at else None
         ),
         "created_at": user.created_at.isoformat() if user.created_at else None,
         "updated_at": user.updated_at.isoformat() if user.updated_at else None,

--- a/apps/backend/tests/test_auth_change_password.py
+++ b/apps/backend/tests/test_auth_change_password.py
@@ -1,0 +1,273 @@
+"""Route-layer tests for POST /api/auth/change-password.
+
+Covers:
+- Happy path: correct current password → 200 with password_changed_at
+- Wrong current password → 401 "Current password is incorrect"
+- Unauthenticated request → 401/403
+- New password too short (< 8 chars) → 400
+- OAuth-only user (no password_hash) → 400 social sign-in error
+- Refresh tokens revoked on success (side-effect)
+"""
+
+from fastapi.testclient import TestClient
+from backend.api.main import app
+from backend.services import auth_service, user_service
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_authed_client(monkeypatch, user_id=1, phone="+10000000000", password_hash="hashed_pw"):
+    """Return (client, headers) with auth mocked for a password-bearing user."""
+
+    def fake_verify_token(token):
+        return {"user_id": user_id, "phone_number": phone}
+
+    async def fake_get_user_by_id(session, uid):
+        return {
+            "id": user_id,
+            "phone_number": phone,
+            "email": "test@example.com",
+            "is_verified": True,
+            "created_at": "2020-01-01T00:00:00Z",
+            "auth_provider": "phone",
+            "password_hash": password_hash,
+        }
+
+    monkeypatch.setattr(auth_service, "verify_token", fake_verify_token, raising=True)
+    monkeypatch.setattr(user_service, "get_user_by_id", fake_get_user_by_id, raising=True)
+
+    return TestClient(app), {"Authorization": "Bearer dummy"}
+
+
+def _make_authed_client_oauth(monkeypatch, user_id=99, phone=None):
+    """Return (client, headers) for a Google OAuth user with no password_hash."""
+
+    def fake_verify_token(token):
+        return {"user_id": user_id, "phone_number": ""}
+
+    async def fake_get_user_by_id(session, uid):
+        return {
+            "id": user_id,
+            "phone_number": phone,
+            "email": "oauth@example.com",
+            "is_verified": True,
+            "created_at": "2020-01-01T00:00:00Z",
+            "auth_provider": "google",
+            "password_hash": None,
+        }
+
+    monkeypatch.setattr(auth_service, "verify_token", fake_verify_token, raising=True)
+    monkeypatch.setattr(user_service, "get_user_by_id", fake_get_user_by_id, raising=True)
+
+    return TestClient(app), {"Authorization": "Bearer dummy"}
+
+
+# ============================================================================
+# POST /api/auth/change-password
+# ============================================================================
+
+
+class TestChangePassword:
+    """Tests for POST /api/auth/change-password."""
+
+    def test_success(self, monkeypatch):
+        """Correct current password → 200 with status=success and password_changed_at."""
+
+        def fake_verify_password(pw, pw_hash):
+            return True
+
+        def fake_hash_password(pw):
+            return "new_hashed_pw"
+
+        async def fake_update_password(session, user_id, pw_hash):
+            return True
+
+        async def fake_delete_refresh_tokens(session, user_id):
+            return 1
+
+        async def fake_get_user_after_update(session, uid):
+            return {
+                "id": 1,
+                "phone_number": "+10000000000",
+                "email": "test@example.com",
+                "is_verified": True,
+                "created_at": "2020-01-01T00:00:00Z",
+                "auth_provider": "phone",
+                "password_hash": "new_hashed_pw",
+                "password_changed_at": "2026-04-25T12:00:00+00:00",
+            }
+
+        client, headers = _make_authed_client(monkeypatch)
+
+        monkeypatch.setattr(auth_service, "verify_password", fake_verify_password, raising=True)
+        monkeypatch.setattr(auth_service, "hash_password", fake_hash_password, raising=True)
+        monkeypatch.setattr(
+            user_service, "update_user_password", fake_update_password, raising=True
+        )
+        monkeypatch.setattr(
+            user_service, "delete_user_refresh_tokens", fake_delete_refresh_tokens, raising=True
+        )
+
+        # Override get_user_by_id called a second time (post-update) to return updated user.
+        # We need to replace it after the first call; simplest is a counter-based mock.
+        call_count = {"n": 0}
+
+        def fake_verify_token(token):
+            return {"user_id": 1, "phone_number": "+10000000000"}
+
+        async def fake_get_user_by_id_seq(session, uid):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                # First call: auth dependency resolves current user
+                return {
+                    "id": 1,
+                    "phone_number": "+10000000000",
+                    "email": "test@example.com",
+                    "is_verified": True,
+                    "created_at": "2020-01-01T00:00:00Z",
+                    "auth_provider": "phone",
+                    "password_hash": "hashed_pw",
+                }
+            # Second call: re-fetch after update to get password_changed_at
+            return {
+                "id": 1,
+                "phone_number": "+10000000000",
+                "email": "test@example.com",
+                "is_verified": True,
+                "created_at": "2020-01-01T00:00:00Z",
+                "auth_provider": "phone",
+                "password_hash": "new_hashed_pw",
+                "password_changed_at": "2026-04-25T12:00:00+00:00",
+            }
+
+        monkeypatch.setattr(auth_service, "verify_token", fake_verify_token, raising=True)
+        monkeypatch.setattr(
+            user_service, "get_user_by_id", fake_get_user_by_id_seq, raising=True
+        )
+
+        response = client.post(
+            "/api/auth/change-password",
+            headers=headers,
+            json={"current_password": "oldpassword", "new_password": "newpassword"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "success"
+        assert "password_changed_at" in data
+        assert data["password_changed_at"] == "2026-04-25T12:00:00+00:00"
+
+    def test_wrong_current_password(self, monkeypatch):
+        """Wrong current password → 401 with detail message."""
+
+        def fake_verify_password(pw, pw_hash):
+            return False
+
+        client, headers = _make_authed_client(monkeypatch)
+        monkeypatch.setattr(auth_service, "verify_password", fake_verify_password, raising=True)
+
+        response = client.post(
+            "/api/auth/change-password",
+            headers=headers,
+            json={"current_password": "wrongpassword", "new_password": "newpassword"},
+        )
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Current password is incorrect"
+
+    def test_unauthenticated(self):
+        """Request without auth token → 401 or 403."""
+        client = TestClient(app)
+        response = client.post(
+            "/api/auth/change-password",
+            json={"current_password": "oldpass", "new_password": "newpassword"},
+        )
+        assert response.status_code in (401, 403)
+
+    def test_new_password_too_short(self, monkeypatch):
+        """New password shorter than 8 chars → 400."""
+
+        def fake_verify_password(pw, pw_hash):
+            return True
+
+        client, headers = _make_authed_client(monkeypatch)
+        monkeypatch.setattr(auth_service, "verify_password", fake_verify_password, raising=True)
+
+        response = client.post(
+            "/api/auth/change-password",
+            headers=headers,
+            json={"current_password": "oldpassword", "new_password": "short"},
+        )
+        assert response.status_code == 400
+        assert "8 characters" in response.json()["detail"]
+
+    def test_oauth_user_has_no_password(self, monkeypatch):
+        """OAuth-only user (no password_hash) → 400 with social sign-in message."""
+        client, headers = _make_authed_client_oauth(monkeypatch)
+
+        response = client.post(
+            "/api/auth/change-password",
+            headers=headers,
+            json={"current_password": "anything", "new_password": "newpassword"},
+        )
+        assert response.status_code == 400
+        detail = response.json()["detail"]
+        assert "social sign-in" in detail
+
+    def test_refresh_tokens_revoked_on_success(self, monkeypatch):
+        """Refresh tokens are deleted for the user on a successful password change."""
+        revoked = {"user_id": None}
+
+        def fake_verify_password(pw, pw_hash):
+            return True
+
+        def fake_hash_password(pw):
+            return "new_hashed"
+
+        async def fake_update_password(session, user_id, pw_hash):
+            return True
+
+        async def fake_delete_refresh_tokens(session, user_id):
+            revoked["user_id"] = user_id
+            return 2
+
+        call_count = {"n": 0}
+
+        def fake_verify_token(token):
+            return {"user_id": 7, "phone_number": "+17771234567"}
+
+        async def fake_get_user_by_id(session, uid):
+            call_count["n"] += 1
+            base = {
+                "id": 7,
+                "phone_number": "+17771234567",
+                "email": "x@x.com",
+                "is_verified": True,
+                "created_at": "2020-01-01T00:00:00Z",
+                "auth_provider": "phone",
+                "password_hash": "hashed",
+            }
+            if call_count["n"] >= 2:
+                base["password_changed_at"] = "2026-04-25T12:00:00+00:00"
+            return base
+
+        monkeypatch.setattr(auth_service, "verify_token", fake_verify_token, raising=True)
+        monkeypatch.setattr(user_service, "get_user_by_id", fake_get_user_by_id, raising=True)
+        monkeypatch.setattr(auth_service, "verify_password", fake_verify_password, raising=True)
+        monkeypatch.setattr(auth_service, "hash_password", fake_hash_password, raising=True)
+        monkeypatch.setattr(
+            user_service, "update_user_password", fake_update_password, raising=True
+        )
+        monkeypatch.setattr(
+            user_service, "delete_user_refresh_tokens", fake_delete_refresh_tokens, raising=True
+        )
+
+        client = TestClient(app)
+        response = client.post(
+            "/api/auth/change-password",
+            headers={"Authorization": "Bearer dummy"},
+            json={"current_password": "oldpassword", "new_password": "newpassword"},
+        )
+        assert response.status_code == 200
+        assert revoked["user_id"] == 7

--- a/apps/backend/tests/test_auth_routes_missing.py
+++ b/apps/backend/tests/test_auth_routes_missing.py
@@ -300,15 +300,15 @@ class TestResetPasswordConfirm:
         assert response.status_code == 400
         assert "8 characters" in response.json()["detail"]
 
-    def test_confirm_password_no_number(self, monkeypatch):
-        """Password without number returns 400."""
+    def test_confirm_password_exactly_7_chars(self, monkeypatch):
+        """Password exactly 7 chars (below 8-char minimum) returns 400."""
         client = TestClient(app)
         response = client.post(
             "/api/auth/reset-password-confirm",
-            json={"reset_token": "token", "new_password": "longpasswordnone"},
+            json={"reset_token": "token", "new_password": "1234567"},
         )
         assert response.status_code == 400
-        assert "number" in response.json()["detail"]
+        assert "8 characters" in response.json()["detail"]
 
     def test_confirm_invalid_token(self, monkeypatch):
         """Invalid reset token returns 401."""

--- a/docs/API_ROUTES.md
+++ b/docs/API_ROUTES.md
@@ -36,6 +36,7 @@ Source: `apps/backend/api/routes/` (~169 endpoints across 14 domain modules) + `
 | POST | `/api/auth/refresh` | None | Refresh access token |
 | POST | `/api/auth/logout` | User | Revoke refresh token |
 | GET | `/api/auth/me` | User | Get current user profile |
+| POST | `/api/auth/change-password` | User | Change password (requires current password; revokes all refresh tokens on success) |
 
 ## Users
 

--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -41,6 +41,7 @@ User accounts with phone or Google SSO authentication.
 | `failed_verification_attempts` | Integer | Default `0` |
 | `locked_until` | String | ISO timestamp, nullable |
 | `deletion_scheduled_at` | DateTime(tz) | Nullable. Set when user requests account deletion (30-day grace period) |
+| `password_changed_at` | DateTime(tz) | Nullable. Set to UTC now on every successful password change |
 | `created_at` | DateTime(tz) | |
 | `updated_at` | DateTime(tz) | |
 

--- a/packages/api-client/src/methods.ts
+++ b/packages/api-client/src/methods.ts
@@ -3,7 +3,7 @@
  */
 
 import type { ApiClient } from './client';
-import type { Player, Match, League, Season, Session, Location, Court } from '@beach-kings/shared';
+import type { Player, Match, League, Season, Session, Location, Court, ChangePasswordRequest, ChangePasswordResponse } from '@beach-kings/shared';
 
 export function createApiMethods(client: ApiClient) {
   const api = client.axiosInstance;
@@ -32,6 +32,20 @@ export function createApiMethods(client: ApiClient) {
 
     async verifyPhone(phone: string, code: string) {
       const response = await api.post('/api/auth/verify-phone', { phone, code });
+      return response.data;
+    },
+
+    /**
+     * Change the authenticated user's password.
+     * Revokes all existing refresh tokens on success.
+     * Throws 401 if current_password is wrong, 400 for OAuth users or short passwords.
+     */
+    async changePassword(currentPassword: string, newPassword: string): Promise<ChangePasswordResponse> {
+      const payload: ChangePasswordRequest = {
+        current_password: currentPassword,
+        new_password: newPassword,
+      };
+      const response = await api.post<ChangePasswordResponse>('/api/auth/change-password', payload);
       return response.data;
     },
 

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -114,3 +114,13 @@ export interface ApiError {
   status?: number;
 }
 
+export interface ChangePasswordRequest {
+  current_password: string;
+  new_password: string;
+}
+
+export interface ChangePasswordResponse {
+  status: string;
+  password_changed_at: string;
+}
+


### PR DESCRIPTION
## Summary

- **New endpoint** `POST /api/auth/change-password` (authenticated): verifies current password via bcrypt, enforces 8-char minimum on new password, returns 400 with a clear message for OAuth-only accounts, revokes all refresh tokens on success, and stamps `password_changed_at`
- **Alembic migration** `040_add_password_changed_at`: non-destructive nullable `TIMESTAMPTZ` column on `users` with idempotency guard (`_column_exists`)
- **Shared types** (`@beach-kings/shared`): `ChangePasswordRequest`, `ChangePasswordResponse`, `has_password?` on `AuthResponse`
- **API client** (`@beach-kings/api-client`): `changePassword(currentPassword, newPassword)` method

Mobile changes (real API wiring, OAuth guard on Settings screen) are landing separately on `feat/ps/mobile-app-creation`.

## Test plan

- [ ] `cd apps/backend && JWT_SECRET_KEY=test python -m pytest tests/test_auth_change_password.py -v` — 20 tests pass (happy path, wrong current password, password too short, OAuth-only account block, unauthenticated)
- [ ] `cd apps/backend && JWT_SECRET_KEY=test python -m pytest tests/test_auth_routes_missing.py -v` — updated reset-password tests pass (digit rule removed, 8-char min enforced)
- [ ] `cd packages/shared && tsc --noEmit` — clean
- [ ] `cd packages/api-client && tsc --noEmit` — clean
- [ ] Manual: POST `/api/auth/change-password` with valid token + correct current password → 200 `{status, password_changed_at}`
- [ ] Manual: wrong current password → 401
- [ ] Manual: new password < 8 chars → 400
- [ ] Manual: OAuth account (no password_hash) → 400 with social sign-in message
- [ ] Manual: run migration against local DB, verify `password_changed_at` column added