### PR TITLE
Fix frontend production image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,15 @@ env/
 *.db-shm
 *.db-wal
 node_modules/
+.turbo/
+**/.turbo/
+**/.next/
+**/coverage/
+.claude/
+.agents/
+data/
+thirdparty/
+out/
 .git
 .gitignore
 *.md
@@ -25,6 +34,6 @@ build/
 # Mobile app - exclude from Docker builds (not needed for web/backend)
 # turbo prune will handle dependency analysis without needing mobile source
 apps/mobile/
-
-
-
+# Prevent a removed legacy config from shadowing next.config.ts in stale
+# Docker build contexts/caches.
+apps/web/next.config.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,3 +198,12 @@ jobs:
 
       - name: Build frontend
         run: npm run build
+
+      - name: Build frontend production image
+        run: |
+          docker build \
+            --file Dockerfile.frontend \
+            --build-arg NEXT_PUBLIC_API_URL=https://beachleaguevb.com \
+            --build-arg NEXT_PUBLIC_MAPBOX_TOKEN= \
+            --tag beach-kings/frontend:ci \
+            .

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -2,7 +2,7 @@
 # Uses turbo prune to create a minimal monorepo subset for Docker builds
 
 # Stage 1: Prune the monorepo
-FROM node:20-slim AS pruner
+FROM node:22.13-slim AS pruner
 WORKDIR /app
 
 # Copy the entire monorepo so turbo prune can analyze the full graph
@@ -13,7 +13,7 @@ COPY . .
 RUN npx turbo prune --scope=@beach-kings/web --docker
 
 # Stage 2: Install dependencies and build
-FROM node:20-slim AS builder
+FROM node:22.13-slim AS builder
 WORKDIR /app
 
 # Accept build arguments for NEXT_PUBLIC_* env vars (inlined at build time by Next.js)
@@ -37,12 +37,13 @@ RUN touch apps/web/.env || true
 # Cap Node heap to avoid OOM during build (leave room for OS + other processes)
 ENV NODE_OPTIONS="--max-old-space-size=4096"
 
-# Build Next.js application
+# Build the standalone Next.js application. Webpack is intentional here:
+# Next.js 16 Turbopack currently has standalone output tracing regressions.
 # This will generate the standalone output in apps/web/.next/standalone
-RUN npx turbo run build --filter=@beach-kings/web...
+RUN npm run build:docker --workspace @beach-kings/web
 
 # Stage 3: Production runtime
-FROM node:20-slim AS runner
+FROM node:22.13-slim AS runner
 WORKDIR /app
 
 # Set production environment
@@ -65,5 +66,3 @@ EXPOSE 3000
 
 # Start Next.js standalone server
 CMD ["node", "apps/web/server.js"]
-
-

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "build:docker": "next build --webpack",
     "start": "next start",
     "lint": "eslint .",
     "clean": "rm -rf .next out dist",
@@ -32,6 +33,7 @@
     "test:unit:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@beach-kings/shared": "*",
     "@popperjs/core": "^2.11.8",
     "@react-oauth/google": "^0.13.4",
     "axios": "^1.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -353,6 +353,7 @@
       "name": "@beach-kings/web",
       "version": "0.0.0",
       "dependencies": {
+        "@beach-kings/shared": "*",
         "@popperjs/core": "^2.11.8",
         "@react-oauth/google": "^0.13.4",
         "axios": "^1.19.0",


### PR DESCRIPTION
## Summary
- declare the web app's shared workspace dependency so Turbo includes it in Docker pruning
- exclude generated build artifacts from Docker contexts and align the image with Node 22
- build the standalone image with Webpack and exercise the full production image build in CI

## Verification
- npm ci --ignore-scripts
- npm run build --workspace @beach-kings/web
- docker build --file Dockerfile.frontend --build-arg NEXT_PUBLIC_API_URL=https://beachleaguevb.com --build-arg NEXT_PUBLIC_MAPBOX_TOKEN= --tag beach-kings/frontend:verify .
- container smoke test: GET / returned 200